### PR TITLE
Fix lastupdate regex and native-comp jobs parsing

### DIFF
--- a/README.org
+++ b/README.org
@@ -197,7 +197,9 @@ such as adjusting garbage collection thresholds and compatibility checks.
   ;; ---------------------------------------------------------------------------
   ;;; Native Compilation Optimization
   (setq native-comp-async-report-warnings-errors 'error) ;; Report only errors
-  (setq native-comp-async-jobs-number (or (getenv "EMACS_NATIVE_COMP_JOBS") 4))
+  (setq native-comp-async-jobs-number
+        (string-to-number
+         (or (getenv "EMACS_NATIVE_COMP_JOBS") "4")))
   (setq native-comp-speed 2)
 
   (when (boundp 'native-comp-eln-load-path)
@@ -571,7 +573,7 @@ such as adjusting garbage collection thresholds and compatibility checks.
     (let ((timestamp (concat "$Lastupdate: " (format-time-string "%Y/%m/%d %H:%M:%S") " $")))
       (save-excursion
         (goto-char (point-min))
-        (while (re-search-forward "\\$Lastupdate\\([0-9/: ]*\\)?\\$" nil t)
+        (while (re-search-forward "\\$Lastupdate: [0-9/: ]*\\$" nil t)
           (replace-match timestamp t nil)))))
 
   (add-hook 'before-save-hook #'my:save-buffer-wrapper)


### PR DESCRIPTION
## Summary
- ensure native compilation worker count uses an integer
- fix `$Lastupdate` timestamp regex so it matches the colon

## Testing
- `make tangle` *(fails: `emacs` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884193459048330b56a0d935618de07